### PR TITLE
Add mutable collections

### DIFF
--- a/.changeset/eighty-crabs-return.md
+++ b/.changeset/eighty-crabs-return.md
@@ -1,0 +1,5 @@
+---
+"@tsplus/stdlib": patch
+---
+
+add MutableQueue module

--- a/.changeset/funny-phones-know.md
+++ b/.changeset/funny-phones-know.md
@@ -1,0 +1,5 @@
+---
+"@tsplus/stdlib": patch
+---
+
+add MutableHashMap module

--- a/.changeset/wise-windows-obey.md
+++ b/.changeset/wise-windows-obey.md
@@ -1,0 +1,5 @@
+---
+"@tsplus/stdlib": patch
+---
+
+add MutableHashSet module

--- a/packages/stdlib/_src/collections/mutable.ts
+++ b/packages/stdlib/_src/collections/mutable.ts
@@ -1,2 +1,3 @@
 export * as ListBuffer from "@tsplus/stdlib/collections/mutable/ListBuffer";
 export * as MutableHashMap from "@tsplus/stdlib/collections/mutable/MutableHashMap";
+export * as MutableHashSet from "@tsplus/stdlib/collections/mutable/MutableHashSet";

--- a/packages/stdlib/_src/collections/mutable.ts
+++ b/packages/stdlib/_src/collections/mutable.ts
@@ -1,3 +1,5 @@
+export * as DoublyLinkedList from "@tsplus/stdlib/collections/mutable/DoublyLinkedList";
 export * as ListBuffer from "@tsplus/stdlib/collections/mutable/ListBuffer";
 export * as MutableHashMap from "@tsplus/stdlib/collections/mutable/MutableHashMap";
 export * as MutableHashSet from "@tsplus/stdlib/collections/mutable/MutableHashSet";
+export * as MutableQueue from "@tsplus/stdlib/collections/mutable/MutableQueue";

--- a/packages/stdlib/_src/collections/mutable.ts
+++ b/packages/stdlib/_src/collections/mutable.ts
@@ -1,1 +1,2 @@
 export * as ListBuffer from "@tsplus/stdlib/collections/mutable/ListBuffer";
+export * as MutableHashMap from "@tsplus/stdlib/collections/mutable/MutableHashMap";

--- a/packages/stdlib/_src/collections/mutable/DoublyLinkedList.ts
+++ b/packages/stdlib/_src/collections/mutable/DoublyLinkedList.ts
@@ -1,0 +1,139 @@
+export class LinkedListNode<T> {
+  public removed = false;
+  public left: LinkedListNode<T> | undefined;
+  public right: LinkedListNode<T> | undefined;
+
+  public constructor(public readonly value: T) {
+    this.right = undefined;
+    this.left = undefined;
+  }
+}
+
+type Node<T> = LinkedListNode<T> | undefined;
+
+/**
+ * @tsplus type DoublyLinkedList
+ */
+export class DoublyLinkedList<T> implements Collection<T> {
+  public get head(): T | undefined {
+    return this.headN === undefined ? undefined : this.headN.value;
+  }
+
+  public get isEmpty(): boolean {
+    return this.length === 0;
+  }
+
+  public get tail(): T | undefined {
+    return this.tailN === undefined ? undefined : this.tailN.value;
+  }
+
+  public length = 0;
+
+  private headN: Node<T> = undefined;
+  private tailN: Node<T> = undefined;
+
+  public forEach(f: (_: T) => void): void {
+    let current = this.headN;
+
+    while (current !== undefined) {
+      f(current.value);
+      current = current.right;
+    }
+  }
+
+  public add(value: T): LinkedListNode<T> {
+    const node = new LinkedListNode(value);
+    if (this.length === 0) {
+      this.headN = node;
+    }
+    if (this.tailN === undefined) {
+      this.tailN = node;
+    } else {
+      this.tailN.right = node;
+      node.left = this.tailN;
+      this.tailN = node;
+    }
+    this.length += 1;
+
+    return node;
+  }
+
+  public empty(): void {
+    this.length = 0;
+    this.headN = this.tailN = undefined;
+  }
+
+  public pop(): T | undefined {
+    const h = this.tailN;
+    if (h !== undefined) {
+      this.remove(h);
+
+      return h.value;
+    }
+
+    return undefined;
+  }
+
+  public remove(n: LinkedListNode<T>): void {
+    if (n.removed) {
+      return;
+    }
+
+    n.removed = true;
+
+    if (n.left !== undefined && n.right !== undefined) {
+      n.left.right = n.right;
+      n.right.left = n.left;
+    } else if (n.left !== undefined) {
+      this.tailN = n.left;
+      n.left.right = undefined;
+    } else if (n.right !== undefined) {
+      this.headN = n.right;
+      n.right.left = undefined;
+    } else {
+      this.tailN = undefined;
+      this.headN = undefined;
+    }
+
+    if (this.length > 0) {
+      this.length -= 1;
+    }
+  }
+
+  public shift(): T | undefined {
+    const h = this.headN;
+    if (h !== undefined) {
+      this.remove(h);
+
+      return h.value;
+    }
+
+    return undefined;
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    let done = false;
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let head: Node<T> | undefined = this.headN;
+    return {
+      next() {
+        if (done) {
+          return this.return!();
+        }
+        if (head == null) {
+          done = true;
+          return this.return!();
+        }
+        const value = head.value;
+        head = head.right;
+        return { done, value };
+      },
+      return(value?: unknown) {
+        if (!done) {
+          done = true;
+        }
+        return { done: true, value };
+      }
+    };
+  }
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap.ts
@@ -1,0 +1,7 @@
+// codegen:start {preset: barrel, include: ./MutableHashMap/*.ts, prefix: "@tsplus/stdlib/collections/mutable"}
+export * from "@tsplus/stdlib/collections/mutable/MutableHashMap/definition";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashMap/empty";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashMap/fromEntries";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashMap/has";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashMap/modify";
+// codegen:end

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap/definition.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap/definition.ts
@@ -1,0 +1,162 @@
+export const MutableHashMapSym = Symbol.for("@tsplus/stdlib/collections/mutable/MutableHashMap");
+export type MutableHashMapSym = typeof MutableHashMapSym;
+
+export const _K = Symbol.for("@tsplus/stdlib/collections/mutable/MutableHashMap/K");
+export type _K = typeof _K;
+
+export const _V = Symbol.for("@tsplus/stdlib/collections/mutable/MutableHashMap/V");
+export type _V = typeof _V;
+
+/**
+ * A mutable `HashMap`.
+ *
+ * @tsplus type MutableHashMap
+ * @tsplus companion MutableHashMap/Ops
+ */
+export class MutableHashMap<K, V> implements Collection<Tuple<[K, V]>> {
+  readonly [MutableHashMapSym]: MutableHashMapSym = MutableHashMapSym;
+  readonly [_K]!: () => K;
+  readonly [_V]!: () => V;
+
+  #backingMap = new Map<number, Node<K, V>>();
+  #length = new AtomicNumber(0);
+
+  get size(): number {
+    return this.#length.get;
+  }
+
+  get(k: K): Option<V> {
+    const hash = Hash.unknown(k);
+    const arr = this.#backingMap.get(hash);
+
+    if (arr == null) {
+      return Option.none;
+    }
+
+    let c: Node<K, V> | undefined = arr;
+
+    while (c) {
+      if (Equals.equals(k, c.k)) {
+        return Option.some(c.v);
+      }
+      c = c.next;
+    }
+
+    return Option.none;
+  }
+
+  remove(k: K): MutableHashMap<K, V> {
+    const hash = Hash.unknown(k);
+    const arr = this.#backingMap.get(hash);
+
+    if (arr == null) {
+      return this;
+    }
+
+    if (Equals.equals(k, arr.k)) {
+      if (arr.next != null) {
+        this.#backingMap.set(hash, arr.next);
+      } else {
+        this.#backingMap.delete(hash);
+      }
+      this.#length.decrementAndGet();
+      return this;
+    }
+
+    let next: Node<K, V> | undefined = arr.next;
+    let curr = arr;
+
+    while (next) {
+      if (Equals.equals(k, next.k)) {
+        curr.next = next.next;
+        this.#length.decrementAndGet();
+        return this;
+      }
+      curr = next;
+      next = next.next;
+    }
+
+    return this;
+  }
+
+  set(k: K, v: V): MutableHashMap<K, V> {
+    const hash = Hash.unknown(k);
+    const arr = this.#backingMap.get(hash);
+
+    if (arr == null) {
+      this.#backingMap.set(hash, new Node(k, v));
+      this.#length.incrementAndGet();
+      return this;
+    }
+
+    let c: Node<K, V> | undefined = arr;
+    let l = arr;
+
+    while (c) {
+      if (Equals.equals(k, c.k)) {
+        c.v = v;
+        return this;
+      }
+      l = c;
+      c = c.next;
+    }
+
+    this.#length.incrementAndGet();
+    l.next = new Node(k, v);
+    return this;
+  }
+
+  update(k: K, f: (v: V) => V): MutableHashMap<K, V> {
+    const hash = Hash.unknown(k);
+    const arr = this.#backingMap.get(hash);
+
+    if (arr == null) {
+      return this;
+    }
+
+    let c: Node<K, V> | undefined = arr;
+
+    while (c) {
+      if (Equals.equals(k, c.k)) {
+        c.v = f(c.v);
+        return this;
+      }
+      c = c.next;
+    }
+
+    return this;
+  }
+
+  [Symbol.iterator](): Iterator<Tuple<[K, V]>> {
+    return ImmutableArray.from(this.#backingMap.values())
+      .map((node) => Tuple(node.k, node.v))[Symbol.iterator]();
+  }
+}
+
+class Node<K, V> implements Iterable<Tuple<[K, V]>> {
+  constructor(readonly k: K, public v: V, public next?: Node<K, V>) {}
+
+  [Symbol.iterator](): Iterator<Tuple<[K, V]>> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let c: Node<K, V> | undefined = this;
+    let n = 0;
+    return {
+      next: () => {
+        if (c) {
+          const kv = Tuple(c.k, c.v);
+          c = c.next;
+          n++;
+          return {
+            value: kv,
+            done: false
+          };
+        } else {
+          return {
+            value: n,
+            done: true
+          };
+        }
+      }
+    };
+  }
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap/empty.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap/empty.ts
@@ -1,0 +1,8 @@
+/**
+ * Creates a new empty `MutableHashMap`.
+ *
+ * @tsplus static MutableHashMap/Ops empty
+ */
+export function empty<K, V>() {
+  return new MutableHashMap<K, V>();
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap/fromEntries.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap/fromEntries.ts
@@ -1,0 +1,22 @@
+/**
+ * Constructs a new `MutableHashMap` from an array of key/value pairs.
+ *
+ * @tsplus static MutableHashMap/Ops __call
+ */
+export function fromEntries<Entries extends Tuple<[any, any]>[]>(
+  ...entries: Entries
+): MutableHashMap<
+  Entries[number] extends Tuple<[infer K, any]> ? K : never,
+  Entries[number] extends Tuple<[any, infer V]> ? V : never
+> {
+  const map = MutableHashMap.empty<
+    Entries[number] extends Tuple<[infer K, any]> ? K : never,
+    Entries[number] extends Tuple<[any, infer V]> ? V : never
+  >();
+
+  for (const entry of entries) {
+    map.set(entry.get(0), entry.get(1));
+  }
+
+  return map;
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap/has.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap/has.ts
@@ -1,0 +1,8 @@
+/**
+ * @tsplus fluent MutableHashMap has
+ */
+export function has_<K, V>(self: MutableHashMap<K, V>, key: K): boolean {
+  return self.get(key).isSome();
+}
+
+export const has = Pipeable(has_);

--- a/packages/stdlib/_src/collections/mutable/MutableHashMap/modify.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashMap/modify.ts
@@ -1,0 +1,35 @@
+/**
+ * Alter the value stored for `key` in the `MutableHashMap` using the specified
+ * function `f`, which uses the internal hash function.
+ *
+ * `f` will be invoked with the current value for `k` if it exists, or `None`
+ *  if no such value exists.
+ *
+ * `modify` will always either update or insert a value into the map.
+ *
+ * @tsplus fluent MutableHashMap modify
+ */
+export function modify_<K, V>(
+  self: MutableHashMap<K, V>,
+  key: K,
+  f: (value: Option<V>) => Option<V>
+) {
+  const result = f(self.get(key));
+  if (result.isSome()) {
+    self.set(key, result.value);
+  } else {
+    self.remove(key);
+  }
+  return self;
+}
+
+/**
+ * Alter the value stored for `key` in the `MutableHashMap` using the specified
+ * function `f`, which uses the internal hash function.
+ *
+ * `f` will be invoked with the current value for `k` if it exists, or `None`
+ *  if no such value exists.
+ *
+ * `modify` will always either update or insert a value into the map.
+ */
+export const modify = Pipeable(modify_);

--- a/packages/stdlib/_src/collections/mutable/MutableHashSet.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashSet.ts
@@ -1,0 +1,6 @@
+// codegen:start {preset: barrel, include: ./MutableHashSet/*.ts, prefix: "@tsplus/stdlib/collections/mutable"}
+export * from "@tsplus/stdlib/collections/mutable/MutableHashSet/definition";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashSet/empty";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashSet/from";
+export * from "@tsplus/stdlib/collections/mutable/MutableHashSet/make";
+// codegen:end

--- a/packages/stdlib/_src/collections/mutable/MutableHashSet/definition.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashSet/definition.ts
@@ -1,0 +1,38 @@
+/**
+ * @tsplus type MutableHashSet
+ * @tsplus companion MutableHashSet/Ops
+ */
+export class MutableHashSet<A> implements Collection<A> {
+  #hashMap: MutableHashMap<A, boolean>;
+
+  constructor() {
+    this.#hashMap = MutableHashMap.empty();
+  }
+
+  get size(): number {
+    return this.#hashMap.size;
+  }
+
+  isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  contains(value: A): boolean {
+    return this.#hashMap.has(value);
+  }
+
+  add(value: A): boolean {
+    this.#hashMap.set(value, true);
+    return this.#hashMap.has(value);
+  }
+
+  remove(value: A): boolean {
+    this.#hashMap.remove(value);
+
+    return !this.#hashMap.has(value);
+  }
+
+  [Symbol.iterator](): Iterator<A> {
+    return this.#hashMap.map(({ tuple: [a] }) => a)[Symbol.iterator]();
+  }
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashSet/empty.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashSet/empty.ts
@@ -1,0 +1,8 @@
+/**
+ * Creates a new empty `MutableHashSet`.
+ *
+ * @tsplus static MutableHashSet/Ops empty
+ */
+export function empty<A>(): MutableHashSet<A> {
+  return new MutableHashSet();
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashSet/from.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashSet/from.ts
@@ -1,0 +1,12 @@
+/**
+ * Construct a new `MutableHashSet` from a `Collection` of values
+ *
+ * @tsplus static MutableHashSet/Ops from
+ */
+export function from<A>(elements: Collection<A>): MutableHashSet<A> {
+  const set = MutableHashSet.empty<A>();
+  for (const value of elements) {
+    set.add(value);
+  }
+  return set;
+}

--- a/packages/stdlib/_src/collections/mutable/MutableHashSet/make.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableHashSet/make.ts
@@ -1,0 +1,12 @@
+/**
+ * Construct a new `MutableHashSet` from a variable number of values.
+ *
+ * @tsplus static MutableHashSet/Ops __call
+ */
+export function make<A>(...elements: Array<A>): MutableHashSet<A> {
+  const set = MutableHashSet.empty<A>();
+  for (const value of elements) {
+    set.add(value);
+  }
+  return set;
+}

--- a/packages/stdlib/_src/collections/mutable/MutableQueue.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue.ts
@@ -1,0 +1,5 @@
+// codegen:start {preset: barrel, include: ./MutableQueue/*.ts, prefix: "@tsplus/stdlib/collections/mutable"}
+export * from "@tsplus/stdlib/collections/mutable/MutableQueue/bounded";
+export * from "@tsplus/stdlib/collections/mutable/MutableQueue/definition";
+export * from "@tsplus/stdlib/collections/mutable/MutableQueue/unbounded";
+// codegen:end

--- a/packages/stdlib/_src/collections/mutable/MutableQueue/_internal/Bounded.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue/_internal/Bounded.ts
@@ -1,0 +1,84 @@
+import { EmptyMutableQueue, MutableQueueSym } from "@tsplus/stdlib/collections/mutable/MutableQueue/definition";
+
+export class Bounded<A> implements MutableQueue<A> {
+  readonly [MutableQueueSym]: MutableQueueSym = MutableQueueSym;
+
+  #queue = new DoublyLinkedList<A>();
+
+  #max: number;
+
+  constructor(max: number) {
+    this.#max = max;
+  }
+
+  get size(): number {
+    return this.#queue.length;
+  }
+
+  get isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  get isFull(): boolean {
+    return this.size === this.capacity;
+  }
+
+  get capacity(): number {
+    return this.#max;
+  }
+
+  offer(value: A): boolean {
+    if (this.isFull) {
+      return false;
+    }
+    this.#queue.add(value);
+    return true;
+  }
+
+  offerAll(as: Collection<A>): Chunk<A> {
+    const it = as[Symbol.iterator]();
+    let next;
+    let rem = Chunk.empty<A>();
+    let offering = true;
+
+    while (offering && (next = it.next()) && !next.done) {
+      offering = this.offer(next.value);
+    }
+
+    while (next && !next.done) {
+      rem = rem.append(next.value);
+      next = it.next();
+    }
+
+    return rem;
+  }
+
+  poll<D>(a: D): A | D {
+    if (this.isEmpty) {
+      return a;
+    }
+    return this.#queue.shift()!;
+  }
+
+  pollUpTo(n: number): Chunk<A> {
+    let result = Chunk.empty<A>();
+    let count = 0;
+
+    while (count < n) {
+      const elem = this.poll(EmptyMutableQueue);
+
+      if (elem === EmptyMutableQueue) {
+        break;
+      }
+
+      result = result.append(elem);
+      count += 1;
+    }
+
+    return result;
+  }
+
+  [Symbol.iterator](): Iterator<A> {
+    return this.#queue[Symbol.iterator]();
+  }
+}

--- a/packages/stdlib/_src/collections/mutable/MutableQueue/_internal/Unbounded.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue/_internal/Unbounded.ts
@@ -1,0 +1,62 @@
+import { EmptyMutableQueue, MutableQueueSym } from "@tsplus/stdlib/collections/mutable/MutableQueue/definition";
+
+export class Unbounded<A> implements MutableQueue<A> {
+  readonly [MutableQueueSym]: MutableQueueSym = MutableQueueSym;
+
+  #queue = new DoublyLinkedList<A>();
+
+  get size(): number {
+    return this.#queue.length;
+  }
+
+  get isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  get isFull(): boolean {
+    return false;
+  }
+
+  get capacity(): number {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  offer(a: A): boolean {
+    this.#queue.add(a);
+    return true;
+  }
+
+  offerAll(as: Collection<A>): Chunk<A> {
+    for (const a of as) {
+      this.offer(a);
+    }
+    return Chunk.empty();
+  }
+
+  poll<D>(a: D): A | D {
+    if (this.isEmpty) {
+      return a;
+    }
+    return this.#queue.shift()!;
+  }
+
+  pollUpTo(n: number): Chunk<A> {
+    let result = Chunk.empty<A>();
+    let count = 0;
+
+    while (count < n) {
+      const elem = this.poll(EmptyMutableQueue);
+      if (elem === EmptyMutableQueue) {
+        break;
+      }
+      result = result.append(elem);
+      count += 1;
+    }
+
+    return result;
+  }
+
+  [Symbol.iterator](): Iterator<A> {
+    return this.#queue[Symbol.iterator]();
+  }
+}

--- a/packages/stdlib/_src/collections/mutable/MutableQueue/bounded.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue/bounded.ts
@@ -1,0 +1,10 @@
+import { Bounded } from "@tsplus/stdlib/collections/mutable/MutableQueue/_internal/Bounded";
+
+/**
+ * Creates a new bounded `MutableQueue`.
+ *
+ * @tsplus static MutableQueue/Ops bounded
+ */
+export function bounded<A>(n: number): MutableQueue<A> {
+  return new Bounded(n);
+}

--- a/packages/stdlib/_src/collections/mutable/MutableQueue/definition.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue/definition.ts
@@ -1,0 +1,72 @@
+export const MutableQueueSym = Symbol.for("@tsplus/stdlib/collections/mutable/MutableQueue");
+export type MutableQueueSym = typeof MutableQueueSym;
+
+export const EmptyMutableQueue = Symbol.for("@tsplus/stdlib/collections/mutable/MutableQueue/Empty");
+export type EmptyMutableQueue = typeof EmptyMutableQueue;
+
+/**
+ * @tsplus type MutableQueue
+ */
+export interface MutableQueue<A> extends Collection<A> {
+  readonly [MutableQueueSym]: MutableQueueSym;
+
+  /**
+   * The **maximum** number of elements that a queue can hold.
+   *
+   * **Note**: unbounded queues can still implement this interface with
+   * `capacity = Number.MAX_SAFE_INTEGER`.
+   */
+  readonly capacity: number;
+
+  /**
+   * Enqueues an element into the queue.
+   *
+   * Returns whether the enqueue was successful or not.
+   */
+  readonly offer: (a: A) => boolean;
+
+  /**
+   * Enqueues a collection of elements into the queue.
+   *
+   * Returns a `Chunk` of the elements that were **not** enqueued.
+   */
+  readonly offerAll: (a: Collection<A>) => Chunk<A>;
+
+  /**
+   * Dequeues an element from the queue.
+   *
+   * Returns either an element from the queue, or the `default` param.
+   *
+   * **Note**: if there is no meaningful default for your type, you can always
+   * use `poll(EmptyMutableQueue)`.
+   */
+  readonly poll: <D>(a: D) => A | D;
+
+  /**
+   * Dequeues up to `n` elements from the queue.
+   *
+   * Returns a `Chunk` of up to `n` elements.
+   */
+  readonly pollUpTo: (n: number) => Chunk<A>;
+
+  /**
+   * Returns the current number of elements in the queue.
+   */
+  readonly size: number;
+
+  /**
+   * Returns whether or not the queue is empty.
+   */
+  readonly isEmpty: boolean;
+
+  /**
+   * Returns whether or not the queue is full.
+   */
+  readonly isFull: boolean;
+}
+
+/**
+ * @tsplus type MutableQueue/Ops
+ */
+export interface MutableQueueOps {}
+export const MutableQueue: MutableQueueOps = {};

--- a/packages/stdlib/_src/collections/mutable/MutableQueue/unbounded.ts
+++ b/packages/stdlib/_src/collections/mutable/MutableQueue/unbounded.ts
@@ -1,0 +1,10 @@
+import { Unbounded } from "@tsplus/stdlib/collections/mutable/MutableQueue/_internal/Unbounded";
+
+/**
+ * Creates a new unbounded `MutableQueue`.
+ *
+ * @tsplus static MutableQueue/Ops unbounded
+ */
+export function unbounded<A>(): MutableQueue<A> {
+  return new Unbounded();
+}

--- a/packages/stdlib/_test/MutableHashMap.test.ts
+++ b/packages/stdlib/_test/MutableHashMap.test.ts
@@ -1,0 +1,131 @@
+class Key implements Equals {
+  constructor(readonly a: number, readonly b: number) {}
+
+  [Hash.sym]() {
+    return Hash.string(`${this.a}-${this.b}`);
+  }
+
+  [Equals.sym](that: unknown): boolean {
+    return that instanceof Key && this.a === that.a && this.b === that.b;
+  }
+}
+
+class Value implements Equals {
+  constructor(readonly c: number, readonly d: number) {}
+
+  [Hash.sym]() {
+    return Hash.string(`${this.c}-${this.d}`);
+  }
+
+  [Equals.sym](that: unknown): boolean {
+    return that instanceof Value && this.c === that.c && this.d === that.d;
+  }
+}
+
+function key(a: number, b: number): Key {
+  return new Key(a, b);
+}
+
+function value(c: number, d: number): Value {
+  return new Value(c, d);
+}
+
+describe("MutableHashMap", () => {
+  it("from", () => {
+    const map = MutableHashMap(Tuple(key(0, 0), value(0, 0)), Tuple(key(1, 1), value(1, 1)));
+
+    assert.strictEqual(map.size, 2);
+    assert.isTrue(map.has(key(0, 0)));
+    assert.isTrue(map.has(key(1, 1)));
+  });
+
+  it("get", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(0, 0), value(1, 1));
+
+    const result = map.get(key(0, 0));
+
+    assert.isTrue(result == Option.some(value(1, 1)));
+  });
+
+  it("has", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(0, 0), value(1, 1))
+      .set(key(1, 1), value(2, 2))
+      .set(key(1, 1), value(3, 3))
+      .set(key(0, 0), value(4, 4));
+
+    assert.isTrue(map.has(key(0, 0)));
+    assert.isTrue(map.has(key(1, 1)));
+    assert.isFalse(map.has(key(4, 4)));
+  });
+
+  it("modify", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(1, 1), value(1, 1));
+
+    map.modify(key(0, 0), () => Option.some(value(0, 1)));
+
+    assert.strictEqual(map.size, 2);
+    assert.isTrue(map.get(key(0, 0)) == Option.some(value(0, 1)));
+
+    map.modify(key(2, 2), (option) => option.fold(Option.some(value(2, 2)), Option.some));
+
+    assert.strictEqual(map.size, 3);
+    assert.isTrue(map.get(key(2, 2)) == Option.some(value(2, 2)));
+  });
+
+  it("remove", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(1, 1), value(1, 1));
+
+    assert.strictEqual(map.size, 2);
+    assert.isTrue(map.has(key(1, 1)));
+
+    map.remove(key(1, 1));
+
+    assert.strictEqual(map.size, 1);
+    assert.isFalse(map.has(key(1, 1)));
+  });
+
+  it("set", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(0, 0), value(1, 1))
+      .set(key(1, 1), value(2, 2))
+      .set(key(1, 1), value(3, 3))
+      .set(key(0, 0), value(4, 4));
+
+    assert.isTrue(
+      map.asImmutableArray() == ImmutableArray(
+        Tuple(key(0, 0), value(4, 4)),
+        Tuple(key(1, 1), value(3, 3))
+      )
+    );
+  });
+
+  it("size", () => {
+    const map = HashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(0, 0), value(1, 1))
+      .set(key(1, 1), value(2, 2))
+      .set(key(1, 1), value(3, 3))
+      .set(key(0, 0), value(4, 4));
+
+    assert.strictEqual(map.size, 2);
+  });
+
+  it("update", () => {
+    const map = MutableHashMap.empty<Key, Value>()
+      .set(key(0, 0), value(0, 0))
+      .set(key(1, 1), value(1, 1));
+
+    map.update(key(0, 0), (v) => value(v.c + 1, v.d + 1));
+
+    assert.isTrue(map.get(key(0, 0)) == Option.some(value(1, 1)));
+  });
+});

--- a/packages/stdlib/_test/MutableHashSet.test.ts
+++ b/packages/stdlib/_test/MutableHashSet.test.ts
@@ -1,0 +1,64 @@
+class Value implements Equals {
+  constructor(readonly n: number) {}
+
+  [Hash.sym](): number {
+    return Hash.number(this.n);
+  }
+
+  [Equals.sym](u: unknown): boolean {
+    return u instanceof Value && this.n === u.n;
+  }
+}
+
+function value(n: number): Value {
+  return new Value(n);
+}
+
+describe("MutableHashSet", () => {
+  it("add", () => {
+    const set = MutableHashSet.empty<Value>();
+
+    set.add(value(0));
+    set.add(value(1));
+    set.add(value(1));
+
+    assert.strictEqual(set.size, 2);
+    assert.isTrue(set.contains(value(0)));
+    assert.isTrue(set.contains(value(1)));
+  });
+
+  it("contains", () => {
+    const set = MutableHashSet(value(0), value(1), value(1));
+
+    assert.isTrue(set.contains(value(0)));
+    assert.isFalse(set.contains(value(4)));
+  });
+
+  it("isEmpty", () => {
+    const emptySet = MutableHashSet.empty<Value>();
+    const set = MutableHashSet(value(0), value(1), value(2));
+
+    assert.isTrue(emptySet.isEmpty());
+    assert.isFalse(set.isEmpty());
+  });
+
+  it("remove", () => {
+    const set = MutableHashSet(value(0), value(1), value(1));
+
+    assert.strictEqual(set.size, 2);
+    assert.isTrue(set.contains(value(1)));
+
+    set.remove(value(1));
+
+    assert.strictEqual(set.size, 1);
+    assert.isFalse(set.contains(value(1)));
+  });
+
+  it("size", () => {
+    const emptySet = MutableHashSet.empty<Value>();
+    const set = MutableHashSet(value(0), value(1), value(1));
+
+    assert.strictEqual(emptySet.size, 0);
+    assert.strictEqual(set.size, 2);
+  });
+});

--- a/packages/stdlib/_test/MutableQueue.test.ts
+++ b/packages/stdlib/_test/MutableQueue.test.ts
@@ -1,0 +1,175 @@
+import { EmptyMutableQueue } from "@tsplus/stdlib/collections/mutable/MutableQueue";
+
+describe("MutableQueue", () => {
+  describe("bounded", () => {
+    it("capacity", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      assert.strictEqual(queue.capacity, 2);
+    });
+
+    it("isEmpty", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      assert.isTrue(queue.isEmpty);
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.isFalse(queue.isEmpty);
+    });
+
+    it("isFull", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      assert.isFalse(queue.isFull);
+
+      queue.offer(0);
+
+      assert.isFalse(queue.isFull);
+
+      queue.offer(1);
+
+      assert.isTrue(queue.isFull);
+    });
+
+    it("offer", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      queue.offer(0);
+      queue.offer(1);
+      queue.offer(2);
+
+      assert.isTrue(
+        queue.asImmutableArray() == ImmutableArray(0, 1)
+      );
+    });
+
+    it("offerAll", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.isTrue(
+        queue.asImmutableArray() == ImmutableArray(0, 1)
+      );
+    });
+
+    it("poll", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      assert.strictEqual(queue.poll(EmptyMutableQueue), EmptyMutableQueue);
+
+      queue.offer(0);
+
+      assert.strictEqual(queue.poll(EmptyMutableQueue), 0);
+    });
+
+    it("pollUpTo", () => {
+      const queue = MutableQueue.bounded<number>(5);
+
+      assert.isTrue(queue.pollUpTo(2) == Chunk.empty());
+
+      queue.offerAll(ImmutableArray(1, 2, 3, 4, 5));
+
+      assert.strictEqual(queue.size, 5);
+      assert.isTrue(queue.pollUpTo(2) == Chunk(1, 2));
+      assert.strictEqual(queue.size, 3);
+    });
+
+    it("size", () => {
+      const queue = MutableQueue.bounded<number>(2);
+
+      assert.strictEqual(queue.size, 0);
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.strictEqual(queue.size, 2);
+    });
+  });
+
+  describe("unbounded", () => {
+    it("capacity", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.strictEqual(queue.capacity, Number.MAX_SAFE_INTEGER);
+    });
+
+    it("isEmpty", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.isTrue(queue.isEmpty);
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.isFalse(queue.isEmpty);
+    });
+
+    it("isFull", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.isFalse(queue.isFull);
+
+      queue.offer(0);
+
+      assert.isFalse(queue.isFull);
+
+      queue.offerAll(ImmutableArray(1, 2, 3, 4, 5));
+
+      assert.isFalse(queue.isFull);
+    });
+
+    it("offer", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      queue.offer(0);
+      queue.offer(1);
+      queue.offer(2);
+
+      assert.isTrue(
+        queue.asImmutableArray() == ImmutableArray(0, 1, 2)
+      );
+    });
+
+    it("offerAll", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.isTrue(
+        queue.asImmutableArray() == ImmutableArray(0, 1, 2, 3, 4, 5)
+      );
+    });
+
+    it("poll", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.strictEqual(queue.poll(EmptyMutableQueue), EmptyMutableQueue);
+
+      queue.offer(0);
+
+      assert.strictEqual(queue.poll(EmptyMutableQueue), 0);
+    });
+
+    it("pollUpTo", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.isTrue(queue.pollUpTo(2) == Chunk.empty());
+
+      queue.offerAll(ImmutableArray(1, 2, 3, 4, 5));
+
+      assert.strictEqual(queue.size, 5);
+      assert.isTrue(queue.pollUpTo(2) == Chunk(1, 2));
+      assert.strictEqual(queue.size, 3);
+    });
+
+    it("size", () => {
+      const queue = MutableQueue.unbounded<number>();
+
+      assert.strictEqual(queue.size, 0);
+
+      queue.offerAll(ImmutableArray(0, 1, 2, 3, 4, 5));
+
+      assert.strictEqual(queue.size, 6);
+    });
+  });
+});

--- a/tsplus.prelude.d.ts
+++ b/tsplus.prelude.d.ts
@@ -29,6 +29,10 @@ import { List } from "@tsplus/stdlib/collections/List/definition";
 /**
  * @tsplus global
  */
+import { DoublyLinkedList } from "@tsplus/stdlib/collections/mutable/DoublyLinkedList";
+/**
+ * @tsplus global
+ */
 import { ListBuffer } from "@tsplus/stdlib/collections/mutable/ListBuffer";
 /**
  * @tsplus global
@@ -38,6 +42,10 @@ import { MutableHashMap } from "@tsplus/stdlib/collections/mutable/MutableHashMa
  * @tsplus global
  */
 import { MutableHashSet } from "@tsplus/stdlib/collections/mutable/MutableHashSet/definition";
+/**
+ * @tsplus global
+ */
+import { MutableQueue } from "@tsplus/stdlib/collections/mutable/MutableQueue/definition";
 /**
  * @tsplus global
  */

--- a/tsplus.prelude.d.ts
+++ b/tsplus.prelude.d.ts
@@ -37,6 +37,10 @@ import { MutableHashMap } from "@tsplus/stdlib/collections/mutable/MutableHashMa
 /**
  * @tsplus global
  */
+import { MutableHashSet } from "@tsplus/stdlib/collections/mutable/MutableHashSet/definition";
+/**
+ * @tsplus global
+ */
 import { ParSeq } from "@tsplus/stdlib/collections/ParSeq/definition";
 /**
  * @tsplus global

--- a/tsplus.prelude.d.ts
+++ b/tsplus.prelude.d.ts
@@ -33,6 +33,10 @@ import { ListBuffer } from "@tsplus/stdlib/collections/mutable/ListBuffer";
 /**
  * @tsplus global
  */
+import { MutableHashMap } from "@tsplus/stdlib/collections/mutable/MutableHashMap/definition";
+/**
+ * @tsplus global
+ */
 import { ParSeq } from "@tsplus/stdlib/collections/ParSeq/definition";
 /**
  * @tsplus global


### PR DESCRIPTION
This PR adds the following mutable collections:
- `MutableHashSet`
- `MutableHashMap`
- `MutableQueue`
- `DoublyLinkedList` (required for `MutableQueue`