### PR TITLE
Add `String` module

### DIFF
--- a/.changeset/honest-pens-wash.md
+++ b/.changeset/honest-pens-wash.md
@@ -1,0 +1,5 @@
+---
+"@tsplus/stdlib": patch
+---
+
+add String module

--- a/packages/stdlib/_src/data.ts
+++ b/packages/stdlib/_src/data.ts
@@ -11,4 +11,5 @@ export * as option from "@tsplus/stdlib/data/Option";
 export * as predicate from "@tsplus/stdlib/data/Predicate";
 export * as result from "@tsplus/stdlib/data/Result";
 export * as stack from "@tsplus/stdlib/data/Stack";
+export * as string from "@tsplus/stdlib/data/String";
 export * as tuple from "@tsplus/stdlib/data/Tuple";

--- a/packages/stdlib/_src/data/String.ts
+++ b/packages/stdlib/_src/data/String.ts
@@ -3,6 +3,10 @@ declare global {
    * @tsplus type string
    */
   export interface String {}
+  /**
+   * @tsplus type string/Ops
+   */
+  export interface StringConstructor {}
 }
 
 /**
@@ -63,11 +67,15 @@ export const takeRight = Pipeable(takeRight_);
 
 /**
  * Represents the character code of a carriage return character (`"\r"`).
+ *
+ * @tsplus static string/Ops CR
  */
 export const CR = 0x0d;
 
 /**
  * Represents the character code of a line-feed character (`"\n"`).
+ *
+ * @tsplus static string/Ops LF
  */
 export const LF = 0x0a;
 

--- a/packages/stdlib/_src/data/String.ts
+++ b/packages/stdlib/_src/data/String.ts
@@ -1,0 +1,205 @@
+declare global {
+  /**
+   * @tsplus type string
+   */
+  export interface String {}
+}
+
+/**
+ * Keep the specified number of characters from the start of a string.
+ *
+ * If `n` is larger than the available number of characters, the string will
+ * be returned whole.
+ *
+ * If `n` is not a positive number, an empty string will be returned.
+ *
+ * If `n` is a float, it will be rounded down to the nearest integer.
+ *
+ * @tsplus fluent string takeLeft
+ */
+export function takeLeft_(self: string, n: number): string {
+  return self.slice(0, Math.max(n, 0));
+}
+
+/**
+ * Keep the specified number of characters from the start of a string.
+ *
+ * If `n` is larger than the available number of characters, the string will
+ * be returned whole.
+ *
+ * If `n` is not a positive number, an empty string will be returned.
+ *
+ * If `n` is a float, it will be rounded down to the nearest integer.
+ */
+export const takeLeft = Pipeable(takeLeft_);
+
+/**
+ * Keep the specified number of characters from the end of a string.
+ *
+ * If `n` is larger than the available number of characters, the string will
+ * be returned whole.
+ *
+ * If `n` is not a positive number, an empty string will be returned.
+ *
+ * If `n` is a float, it will be rounded down to the nearest integer.
+ *
+ * @tsplus fluent string takeRight
+ */
+export function takeRight_(s: string, n: number): string {
+  return s.slice(Math.max(0, s.length - Math.floor(n)), Infinity);
+}
+
+/**
+ * Keep the specified number of characters from the end of a string.
+ *
+ * If `n` is larger than the available number of characters, the string will
+ * be returned whole.
+ *
+ * If `n` is not a positive number, an empty string will be returned.
+ *
+ * If `n` is a float, it will be rounded down to the nearest integer.
+ */
+export const takeRight = Pipeable(takeRight_);
+
+/**
+ * Represents the character code of a carriage return character (`"\r"`).
+ */
+export const CR = 0x0d;
+
+/**
+ * Represents the character code of a line-feed character (`"\n"`).
+ */
+export const LF = 0x0a;
+
+/**
+ * Returns an `IterableIterator` which yields each line contained within the
+ * string, trimming off the trailing newline character.
+ *
+ * @tsplus fluent string linesIterator
+ */
+export function linesIterator(self: string): LinesIterator {
+  return linesSeparated(self, true);
+}
+
+/**
+ * Returns an `IterableIterator` which yields each line contained within the
+ * string as well as the trailing newline character.
+ *
+ * @tsplus fluent string linesIterator
+ */
+export function linesWithSeparators(s: string): LinesIterator {
+  return linesSeparated(s, false);
+}
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the character specified by `marginChar`
+ * from the line.
+ *
+ * @tsplus fluent string stripMarginWith
+ */
+export function stripMarginWith_(self: string, marginChar: string): string {
+  let out = "";
+
+  for (const line of linesWithSeparators(self)) {
+    let index = 0;
+
+    while (index < line.length && line.charAt(index) <= " ") {
+      index = index + 1;
+    }
+
+    const stripped = index < line.length && line.charAt(index) === marginChar
+      ? line.substring(index + 1)
+      : line;
+
+    out = out + stripped;
+  }
+
+  return out;
+}
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the character specified by `marginChar`
+ * from the line.
+ */
+export const stripMarginWith = Pipeable(stripMarginWith_);
+
+/**
+ * For every line in this string, strip a leading prefix consisting of blanks
+ * or control characters followed by the `"|"` character from the line.
+ *
+ * @tsplus fluent string stripMargin
+ */
+export function stripMargin(self: string): string {
+  return self.stripMarginWith("|");
+}
+
+export class LinesIterator implements IterableIterator<string> {
+  private index: number;
+  private length: number;
+
+  constructor(readonly s: string, readonly stripped: boolean = false) {
+    this.index = 0;
+    this.length = s.length;
+  }
+
+  next(): IteratorResult<string> {
+    if (this.done) {
+      return { done: true, value: undefined };
+    }
+
+    const start = this.index;
+
+    while (!this.done && !isLineBreak(this.s[this.index]!)) {
+      this.index = this.index + 1;
+    }
+
+    let end = this.index;
+
+    if (!this.done) {
+      const char = this.s[this.index]!;
+
+      this.index = this.index + 1;
+
+      if (!this.done && isLineBreak2(char, this.s[this.index]!)) {
+        this.index = this.index + 1;
+      }
+
+      if (!this.stripped) {
+        end = this.index;
+      }
+    }
+
+    return { done: false, value: this.s.substring(start, end) };
+  }
+
+  [Symbol.iterator](): IterableIterator<string> {
+    return new LinesIterator(this.s, this.stripped);
+  }
+
+  private get done(): boolean {
+    return this.index >= this.length;
+  }
+}
+
+/**
+ * Test if the provided character is a line break character (i.e. either `"\r"`
+ * or `"\n"`).
+ */
+function isLineBreak(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code === CR || code === LF;
+}
+
+/**
+ * Test if the provided characters combine to form a carriage return/line-feed
+ * (i.e. `"\r\n"`).
+ */
+function isLineBreak2(char0: string, char1: string): boolean {
+  return char0.charCodeAt(0) === CR && char1.charCodeAt(0) === LF;
+}
+
+function linesSeparated(self: string, stripped: boolean): LinesIterator {
+  return new LinesIterator(self, stripped);
+}

--- a/packages/stdlib/_test/String.test.ts
+++ b/packages/stdlib/_test/String.test.ts
@@ -1,0 +1,93 @@
+describe.concurrent("String", () => {
+  describe.concurrent("takeLeft", () => {
+    it("should take the specified number of characters from the left side of a string", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeLeft(7);
+
+      assert.strictEqual(result, "Hello, ");
+    });
+
+    it("should return the string for `n` larger than the string length", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeLeft(100);
+
+      assert.strictEqual(result, string);
+    });
+
+    it("should return the empty string for a negative `n`", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeLeft(-1);
+
+      assert.strictEqual(result, "");
+    });
+
+    it("should round down if `n` is a float", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeLeft(5.5);
+
+      assert.strictEqual(result, "Hello");
+    });
+  });
+
+  describe.concurrent("takeRight", () => {
+    it("should take the specified number of characters from the right side of a string", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeRight(7);
+
+      assert.strictEqual(result, " World!");
+    });
+
+    it("should return the string for `n` larger than the string length", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeRight(100);
+
+      assert.strictEqual(result, string);
+    });
+
+    it("should return the empty string for a negative `n`", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeRight(-1);
+
+      assert.strictEqual(result, "");
+    });
+
+    it("should round down if `n` is a float", () => {
+      const string = "Hello, World!";
+
+      const result = string.takeRight(6.5);
+
+      assert.strictEqual(result, "World!");
+    });
+  });
+
+  describe.concurrent("stripMargin", () => {
+    it("should strip a leading prefix from each line", () => {
+      const string = `|
+    |Hello,
+    |World!
+    |`;
+
+      const result = string.stripMargin();
+
+      assert.strictEqual(result, "\nHello,\nWorld!\n");
+    });
+
+    it("should strip a leading prefix from each line using a margin character", () => {
+      const string = `$
+    $Hello,
+    $World!
+    $`;
+
+      const result = string.stripMarginWith("$");
+
+      assert.strictEqual(result, "\nHello,\nWorld!\n");
+    });
+  });
+});


### PR DESCRIPTION
Adds a minimal `String` module with some useful helpers:
- `stripMargin`
- `stripMarginWith`
- `takeLeft`
- `takeRight`