### PR TITLE
Fix `this is undefined` bug in Env

### DIFF
--- a/.changeset/light-pans-talk.md
+++ b/.changeset/light-pans-talk.md
@@ -1,0 +1,5 @@
+---
+"@tsplus/stdlib": patch
+---
+
+fix `this is undefined` bug in Env

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "@changesets/cli": "^2.22.0",
     "@effect-ts/build-utils": "0.40.2",
     "@effect-ts/core": "^0.60.1",
-    "@repo-tooling/eslint-plugin-dprint": "^0.0.3",
-    "@tsplus/installer": "^0.0.107",
-    "@types/node": "^17.0.35",
+    "@repo-tooling/eslint-plugin-dprint": "^0.0.4",
+    "@tsplus/installer": "^0.0.108",
+    "@types/node": "^17.0.38",
     "@types/rimraf": "^3.0.2",
-    "@typescript-eslint/eslint-plugin": "^5.26.0",
-    "@typescript-eslint/parser": "^5.26.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.0",
+    "@typescript-eslint/parser": "^5.27.0",
     "babel-plugin-annotate-pure-calls": "^0.4.0",
     "babel-plugin-replace-import-extension": "^1.1.3",
     "c8": "^7.11.3",
@@ -61,7 +61,7 @@
     "typescript": "^4.7.2",
     "ultra-runner": "^3.10.5",
     "vite": "^2.9.9",
-    "vitest": "0.12.9"
+    "vitest": "0.13.0"
   },
   "resolutions": {
     "eslint-plugin-codegen": "patch:eslint-plugin-codegen@npm:0.16.1#.yarn/patches/eslint-plugin-codegen-npm-0.16.1-87770191cd"

--- a/packages/stdlib/_src/service/Env.ts
+++ b/packages/stdlib/_src/service/Env.ts
@@ -65,7 +65,7 @@ function pruneMethod<
 const sym = Symbol("@tsplus/stdlib/Env/Env") as EnvOps["sym"]
 export const Env: EnvOps = Object.assign(
   function self(this: any, a: any, b: any) {
-    if (this.constructor === self) {
+    if (this != null && this.constructor === self) {
       return {
         [Env.sym]: identity,
         add: methodAdd,

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,16 +818,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@repo-tooling/eslint-plugin-dprint@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@repo-tooling/eslint-plugin-dprint@npm:0.0.3"
+"@repo-tooling/eslint-plugin-dprint@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@repo-tooling/eslint-plugin-dprint@npm:0.0.4"
   dependencies:
     "@dprint/formatter": ^0.2.0
     "@dprint/typescript": ^0.68.3
     "@typescript-eslint/utils": ^5.0.0
     diff: ^5.0.0
     eslint: ^8.0.0
-  checksum: 8ef304017850b2b1c764912ead5a11469fd53c876364d8b16ec76fff6e761f76f734d96208b8ca9b604df3bab098e8cf201e5114c02e0547cd2a49eab16c85dd
+  checksum: 7c11d0c4785d36426dbb31c1d01fba5e99ee391951251bd1c74e3f9e9c79191b7e08f2c1424b98d4442fed0b828497662aa99477ad0765f9d4fd57fbae17cf3b
   languageName: node
   linkType: hard
 
@@ -866,9 +866,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsplus/installer@npm:^0.0.107":
-  version: 0.0.107
-  resolution: "@tsplus/installer@npm:0.0.107"
+"@tsplus/installer@npm:^0.0.108":
+  version: 0.0.108
+  resolution: "@tsplus/installer@npm:0.0.108"
   dependencies:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
@@ -877,7 +877,7 @@ __metadata:
     zlib: ^1.0.5
   bin:
     tsplus-install: bin/tsplus-install
-  checksum: ec5aa1661d89b27beafb02f0d52092dba19de02122c4b47c8ca27fba41dbd0f8a1af509f588a9ae4c76ce37b74bcb0d424ccfc7abcaf407fab4ac7e00fd2c297
+  checksum: a05e904b3698aa02d3db0b1207d524e4c77b86d7413ad3cd38bf313cbfebc6d9313a2b53776e94bf222c011a32760ba44b6ccd471074e0818f71d42f05c78891
   languageName: node
   linkType: hard
 
@@ -986,10 +986,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^17.0.35":
-  version: 17.0.35
-  resolution: "@types/node@npm:17.0.35"
-  checksum: 7a24946ae7fd20267ed92466384f594e448bfb151081158d565cc635d406ecb29ea8fb85fcd2a1f71efccf26fb5bd3c6f509bde56077eb8b832b847a6664bc62
+"@types/node@npm:*, @types/node@npm:^17.0.38":
+  version: 17.0.38
+  resolution: "@types/node@npm:17.0.38"
+  checksum: 9db1c39d603850ced665ab60b8f8ebce674ff9d762dfff0f776d520e71e4d73fdcd4c7f69213b804d878cf3e726911b09cae4ee66e35ae2724538de9f4838681
   languageName: node
   linkType: hard
 
@@ -1047,13 +1047,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.26.0"
+"@typescript-eslint/eslint-plugin@npm:^5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.26.0
-    "@typescript-eslint/type-utils": 5.26.0
-    "@typescript-eslint/utils": 5.26.0
+    "@typescript-eslint/scope-manager": 5.27.0
+    "@typescript-eslint/type-utils": 5.27.0
+    "@typescript-eslint/utils": 5.27.0
     debug: ^4.3.4
     functional-red-black-tree: ^1.0.1
     ignore: ^5.2.0
@@ -1066,42 +1066,42 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ea75e57dfb6f95f39d7a4a90f25d5618548ca6026e8836c0962c141908f3bfb6d4a744d7597934572fa25e88c97efb8b9cd25e85785474256d5ebe58f9c1df30
+  checksum: af7970f90c511641c332b7abecc53523fbbcb19e59ec52df9679f02047ddd5fd5e9ce3ca9359b17674ac7e20e380995861482fb6e60049fe8facd766c2bd85fe
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/parser@npm:5.26.0"
+"@typescript-eslint/parser@npm:^5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/parser@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.26.0
-    "@typescript-eslint/types": 5.26.0
-    "@typescript-eslint/typescript-estree": 5.26.0
+    "@typescript-eslint/scope-manager": 5.27.0
+    "@typescript-eslint/types": 5.27.0
+    "@typescript-eslint/typescript-estree": 5.27.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3c13a989d1c5aa3d9050203ca53fa28642fe49b9f09b668b7c424f13bfc8352e0a57d2ae16c55cd9b4f9fb98d730a440b0270a94c827938579df8097f90bdfac
+  checksum: 40ccdc481f871c296ee419e886ffd6f89ec23f6b10dbb2847c7e89bfd2234c6be23c49ab92d2965e16cd4c3cf378010e3dcd72d34f82b1e2ca8b5c812133fb00
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.26.0"
+"@typescript-eslint/scope-manager@npm:5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/types": 5.26.0
-    "@typescript-eslint/visitor-keys": 5.26.0
-  checksum: 56db69b8dc3502261c403c1217f32fb7e8244c1f192c3b486733ad8cd3e7672b365d2c6da7ec8ff40113c4da507c04f4e00b6104ca68579c19525cac828a631b
+    "@typescript-eslint/types": 5.27.0
+    "@typescript-eslint/visitor-keys": 5.27.0
+  checksum: 84eb2d6241a6644c622b473c060bb7a227c2a82e8af8ddcf654fb63716e1b3c6fe1b5d747d032d85594c0ad147d95aabc2b217d4af574b55eab93910e0c292ce
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/type-utils@npm:5.26.0"
+"@typescript-eslint/type-utils@npm:5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/type-utils@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/utils": 5.26.0
+    "@typescript-eslint/utils": 5.27.0
     debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
@@ -1109,7 +1109,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: cafd9fba76df8b184adcb5e6f66e3f0c3b8c6e98debe585abde9d3c4372feee0bc156ed5eed89cd0747938e45c8a4d3d65c43dd561b47e8e12a0207c85e2dc6f
+  checksum: 21ef57ecc0dfa085e7ce8f7714d143993f592004086e37582cb6ab5924cb3358267b607e0701ce43737e01f46fb33d66e3f3428fbb7be6e64971d4c26f73c265
   languageName: node
   linkType: hard
 
@@ -1120,19 +1120,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/types@npm:5.26.0"
-  checksum: 98798616d832da8e5ef61f050e4e72ed921a162cb4ce2b2dfe0a317c66998157e832f449aeab21a1fdfd806e7134091bc1a9446b1089f4687786b646ad8738e7
+"@typescript-eslint/types@npm:5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/types@npm:5.27.0"
+  checksum: d19802bb7bc8202885a47118e196ad9a26b686f00da5aa71a84974c1e838c5e3a36f54116605c46ffe909ccf856a49623f2a095fd05243b4fe4fecfe5cecb89c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.26.0"
+"@typescript-eslint/typescript-estree@npm:5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/types": 5.26.0
-    "@typescript-eslint/visitor-keys": 5.26.0
+    "@typescript-eslint/types": 5.27.0
+    "@typescript-eslint/visitor-keys": 5.27.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -1141,7 +1141,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 2cf147629474952725593da64827a7e4e39f79614019529d0d6e5b89236c55f3607c6b4a24f160dbc5978f4cfd60f96fcb573a770c2877f8e29d7552b40e2135
+  checksum: a0f14c332cd293a100399172c9ae498c230c8c205ab74565ea2de08a0bd860af829a9c4dde1888df89667fa0bc29048bc33993eb9445d2689fa2dfcec55c4915
   languageName: node
   linkType: hard
 
@@ -1163,19 +1163,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.26.0, @typescript-eslint/utils@npm:^5.0.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/utils@npm:5.26.0"
+"@typescript-eslint/utils@npm:5.27.0, @typescript-eslint/utils@npm:^5.0.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/utils@npm:5.27.0"
   dependencies:
     "@types/json-schema": ^7.0.9
-    "@typescript-eslint/scope-manager": 5.26.0
-    "@typescript-eslint/types": 5.26.0
-    "@typescript-eslint/typescript-estree": 5.26.0
+    "@typescript-eslint/scope-manager": 5.27.0
+    "@typescript-eslint/types": 5.27.0
+    "@typescript-eslint/typescript-estree": 5.27.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: c16828ba6bfbe3b0b6e9dadeece1cfd2345141bcd13824f99fe210c76e5ddb11f6f79e61705cafa421c549657da12d1700a1316d24c2eeaee6179b08f512b5fb
+  checksum: ed823528c3b7f8c71a44ea0481896c46178e361e89003c63736de6ece45cb771defea13b505f0adb517c59f55a95d0b5f1bb990f7a24d3a2597aa045bba0a7bf
   languageName: node
   linkType: hard
 
@@ -1189,13 +1189,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.26.0":
-  version: 5.26.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.26.0"
+"@typescript-eslint/visitor-keys@npm:5.27.0":
+  version: 5.27.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.27.0"
   dependencies:
-    "@typescript-eslint/types": 5.26.0
+    "@typescript-eslint/types": 5.27.0
     eslint-visitor-keys: ^3.3.0
-  checksum: 4a5085d19e677f3b44ca4455bba85fd1a3be4d7d2e96bb22738a7497f6f4d16bfdee51059454a78b1e108d8e1593b1a31be40764a66448945118277cff5eff02
+  checksum: 7781f35e25a09d0986b4ba97c707102394cf94738a92d68eca6382b00ffba1b0fac3e937ca4ee6266295dd40ec837a61889fd715f594549f2c3d837594999c29
   languageName: node
   linkType: hard
 
@@ -7288,12 +7288,12 @@ __metadata:
     "@changesets/cli": ^2.22.0
     "@effect-ts/build-utils": 0.40.2
     "@effect-ts/core": ^0.60.1
-    "@repo-tooling/eslint-plugin-dprint": ^0.0.3
-    "@tsplus/installer": ^0.0.107
-    "@types/node": ^17.0.35
+    "@repo-tooling/eslint-plugin-dprint": ^0.0.4
+    "@tsplus/installer": ^0.0.108
+    "@types/node": ^17.0.38
     "@types/rimraf": ^3.0.2
-    "@typescript-eslint/eslint-plugin": ^5.26.0
-    "@typescript-eslint/parser": ^5.26.0
+    "@typescript-eslint/eslint-plugin": ^5.27.0
+    "@typescript-eslint/parser": ^5.27.0
     babel-plugin-annotate-pure-calls: ^0.4.0
     babel-plugin-replace-import-extension: ^1.1.3
     c8: ^7.11.3
@@ -7311,7 +7311,7 @@ __metadata:
     typescript: ^4.7.2
     ultra-runner: ^3.10.5
     vite: ^2.9.9
-    vitest: 0.12.9
+    vitest: 0.13.0
   languageName: unknown
   linkType: soft
 
@@ -7601,7 +7601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^2.9.8, vite@npm:^2.9.9":
+"vite@npm:^2.9.9":
   version: 2.9.9
   resolution: "vite@npm:2.9.9"
   dependencies:
@@ -7630,9 +7630,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:0.12.9":
-  version: 0.12.9
-  resolution: "vitest@npm:0.12.9"
+"vitest@npm:0.13.0":
+  version: 0.13.0
+  resolution: "vitest@npm:0.13.0"
   dependencies:
     "@types/chai": ^4.3.1
     "@types/chai-subset": ^1.3.3
@@ -7641,7 +7641,7 @@ __metadata:
     local-pkg: ^0.4.1
     tinypool: ^0.1.3
     tinyspy: ^0.3.2
-    vite: ^2.9.8
+    vite: ^2.9.9
   peerDependencies:
     "@vitest/ui": "*"
     c8: "*"
@@ -7658,7 +7658,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: efc1c7279273ec594e8a1865c6bc38e758f87e500e2daf971f110b3f845d0d2552813e80b8d9634cca9a10fe626b5a9eb8f5533d9a97e50d7277c3e969cab433
+  checksum: 78c35565cf75e8b0f7689e15a7f4370819ac39394b966711bcafc51a5a3e816034a5fa9726e038edb809dd77cf95441c6f991d8b1dde4fbdcbfb14b05921a5f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In the browser, there was a bug in `Env` where `this` could be `undefined` in the following check:

https://github.com/ts-plus/stdlib/blob/e84407b169e7c5cb5bd66e419d4c8b603f66e02f/packages/stdlib/_src/service/Env.ts#L68-L78

This happens because when doing the first call to `Env()`, it will perform the check, but `this` it's not defined until the first call to `new Env()` is performed in `Env.empty.add()`.